### PR TITLE
Fix invalid font-family declarations in CSS

### DIFF
--- a/rafal 4.html
+++ b/rafal 4.html
@@ -48,7 +48,7 @@ BAWCIE SIĘ
     <title>Rafal 4</title>
     <style>
         body {
-            font-family: 'monospace;', monospace;
+            font-family: 'monospace', monospace;
             background: #0a0a0a;
             color: #ffffff;
             margin: 0;
@@ -135,14 +135,14 @@ BAWCIE SIĘ
             border-radius: 2px;
             font-size: 14px;
             box-sizing: border-box;
-            text-shadow: 1px 2px #000
+            text-shadow: 1px 2px #000;
         }
         input[type="text"], input[type="number"] {
-            font-family: 'monospace;', monospace !important;
+            font-family: 'monospace', monospace !important;
         }
         button {
             background: rgba(220, 20, 60, 1);
-            font-family: 'monospace;', monospace;
+            font-family: 'monospace', monospace;
             cursor: pointer;
             width: auto;
             font-weight: 600;


### PR DESCRIPTION
## Summary
- remove stray semicolons inside `font-family` declarations
- add missing semicolon to `text-shadow` property for consistency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab3769c3a08322a5ed3b15646ce53f